### PR TITLE
Credential adjustments

### DIFF
--- a/UofICDB/Functions/Public/Invoke-CDBRestCall.ps1
+++ b/UofICDB/Functions/Public/Invoke-CDBRestCall.ps1
@@ -27,7 +27,7 @@ function Invoke-CDBRestCall {
     )
 
     begin {
-        if($Script:Authorization -eq [String]::Empty){
+        if($null -eq $Script:Authorization){
             Write-Verbose -Message 'No CDB connection established. Please provide credentials.'
             New-CDBConnection
         }
@@ -39,7 +39,7 @@ function Invoke-CDBRestCall {
 
         $IVRSplat = @{
             'Headers' = @{
-                'Authorization' = $Script:Authorization
+                'Authorization' = ('Basic {0}' -f ([Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(("{0}:{1}" -f $Script:Authorization.UserName,$Script:Authorization.GetNetworkCredential().Password)))))
             }
 
             'Uri' = "$($Script:Settings.CDBURI)$($RelativeURI)$($QueryString)"

--- a/UofICDB/Functions/Public/New-CDBConnection.ps1
+++ b/UofICDB/Functions/Public/New-CDBConnection.ps1
@@ -24,13 +24,15 @@ function New-CDBConnection {
     }
 
     process {
-        $Script:Authorization = 'Basic {0}' -f ([Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(("{0}:{1}" -f $Credential.UserName,$Credential.GetNetworkCredential().Password))))
+        $Script:Authorization = $Credential
         Update-CDBSubclassUris
 
         if($Save){
-            #documentation for the encryption can be found here: https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.security/convertfrom-securestring?view=powershell-7 and https://docs.microsoft.com/en-us/dotnet/standard/security/how-to-use-data-protection
-            #Windows Data Protection API (DPAPI) is used in this context.
-            $Script:Authorization | ConvertTo-SecureString -AsPlainText -Force | ConvertFrom-SecureString | Out-File -FilePath $Script:SavedCredsDir -Force
+            @{
+                Username = $Credential.Username
+                # The password is encrypted when it's written to disk and is only retrievable by the user/system combination.
+                Password = $Credential.Password | ConvertFrom-SecureString
+            } | ConvertTo-Json | Out-File -FilePath $Script:SavedCredsDir
         }
     }
 

--- a/UofICDB/UofICDB.psm1
+++ b/UofICDB/UofICDB.psm1
@@ -11,11 +11,18 @@ $Script:Settings = Get-Content -Path $SettingsPath | ConvertFrom-Json
 
 $Script:SubClassURIs = @{}
 
-[String]$Script:SavedCredsDir = Join-Path -Path $([System.Environment]::GetFolderPath(28)) -ChildPath 'PSCDBAuth.txt'
+[String]$Script:SavedCredsDir = Join-Path -Path $([System.Environment]::GetFolderPath(28)) -ChildPath 'PSCDBAuth2.txt'
+[String]$Script:OldSavedCredsDir = Join-Path -Path $([System.Environment]::GetFolderPath(28)) -ChildPath 'PSCDBAuth.txt'
+
+if(Test-Path -Path $Script:OldSavedCredsDir){
+    Remove-Item -Path $Script:OldSavedCredsDir -Force
+}
+
 if(Test-Path -Path $Script:SavedCredsDir){
-    $Script:Authorization = Get-Content -Path $Script:SavedCredsDir | ConvertTo-SecureString | ConvertFrom-SecureString -AsPlainText
+    $SavedCreds = Get-Content -Path $Script:SavedCredsDir | ConvertFrom-Json
+    $Script:Authorization = New-Object -TypeName PSCredential -ArgumentList ($SavedCreds.Username,($SavedCreds.Password | ConvertTo-SecureString))
     Update-CDBSubclassUris
 }
 else{
-    $Script:Authorization = [String]::Empty
+    $Script:Authorization = $null
 }

--- a/tests/UofICDB.Tests.ps1
+++ b/tests/UofICDB.Tests.ps1
@@ -14,7 +14,7 @@ Describe 'New-CDBConnection'{
 
         InModuleScope 'UofICDB' {
             It 'Sets the credentials at the module level'{
-                $Script:Authorization -ne [String]::Empty | Should -Be $True
+                $null -ne $Script:Authorization | Should -Be $True
             }
         }
     }
@@ -27,8 +27,8 @@ Describe 'New-CDBConnection'{
                 Test-Path -Path $Script:SavedCredsDir | Should -Be $True
             }
 
-            It 'Encrypts the content of the file'{
-                {Get-Content -Path $Script:SavedCredsDir | ConvertTo-SecureString} | Should -Not -Throw
+            It 'Encrypts the saved password'{
+                { (Get-Content -Path $Script:SavedCredsDir | ConvertFrom-Json).password | ConvertTo-SecureString } | Should -Not -Throw
             } 
         }
     }


### PR DESCRIPTION
- Removed encoded credentials from being in script scope. This reduces the attack surface for accessing credentials in memory. With this change they are only exposed in the encoded format required for CDB's auth header within a function scope.

- Tests have been updated appropriately.

- This will be a breaking change requiring previously saved credentials to be re-saved.