### PR TITLE
Fully implemented SupportsShouldProcess for session cmdlets

### DIFF
--- a/.github/workflows/pester.yml
+++ b/.github/workflows/pester.yml
@@ -1,9 +1,11 @@
 name: Pester Tests
 
-on: [pull_request]
+on:
+  pull_request:
     paths:
     - 'src/**'
     - 'test/**'
+
 jobs:
   build:
 

--- a/.github/workflows/pester.yml
+++ b/.github/workflows/pester.yml
@@ -2,6 +2,8 @@ name: Pester Tests
 
 on:
   pull_request:
+    branches:
+    - main
     paths:
     - 'src/**'
     - 'test/**'

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,8 +1,10 @@
 name: ScriptAnalyzer
 
-on: [pull_request]
+on:
+  pull_request:
     paths:
     - 'src/**'
+
 jobs:
   build:
 

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -2,6 +2,8 @@ name: ScriptAnalyzer
 
 on:
   pull_request:
+    branches:
+    - main
     paths:
     - 'src/**'
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    // When enabled, will trim trailing whitespace when you save a file.
+    "files.trimTrailingWhitespace": true
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Added
+- Properly implemented SupportsShouldProcess for New-CDBConnection and New-CDBConnection 
 ### Changed
 ### Removed
 

--- a/src/UofICDB/Functions/Public/New-CDBConnection.ps1
+++ b/src/UofICDB/Functions/Public/New-CDBConnection.ps1
@@ -20,23 +20,25 @@ function New-CDBConnection {
     )
 
     begin {
-
     }
 
     process {
-        $Script:Authorization = $Credential
-        Update-CDBSubclassUris
+        if($PSCmdlet.ShouldProcess("Creating session for $($Credential.UserName)")){
+            $Script:Authorization = $Credential
+            Update-CDBSubclassUris
+        }
 
-        if($Save){
-            @{
-                Username = $Credential.Username
-                # The password is encrypted when it's written to disk and is only retrievable by the user/system combination.
-                Password = $Credential.Password | ConvertFrom-SecureString
-            } | ConvertTo-Json | Out-File -FilePath $Script:SavedCredsDir
+        if($PSCmdlet.ShouldProcess("Caching credentials for $($Credential.UserName) at $($Script:SavedCredsDir)")){
+            if($Save){
+                @{
+                    Username = $Credential.Username
+                    # The password is encrypted when it's written to disk and is only retrievable by the user/system combination.
+                    Password = $Credential.Password | ConvertFrom-SecureString
+                } | ConvertTo-Json | Out-File -FilePath $Script:SavedCredsDir
+            }
         }
     }
 
     end {
-
     }
 }

--- a/src/UofICDB/Functions/Public/New-CDBConnection.ps1
+++ b/src/UofICDB/Functions/Public/New-CDBConnection.ps1
@@ -28,8 +28,8 @@ function New-CDBConnection {
             Update-CDBSubclassUris
         }
 
-        if($PSCmdlet.ShouldProcess("Caching credentials for $($Credential.UserName) at $($Script:SavedCredsDir)")){
-            if($Save){
+        if($Save){
+            if($PSCmdlet.ShouldProcess("Caching credentials for $($Credential.UserName) at $($Script:SavedCredsDir)")){
                 @{
                     Username = $Credential.Username
                     # The password is encrypted when it's written to disk and is only retrievable by the user/system combination.

--- a/src/UofICDB/Functions/Public/Remove-CDBConnection.ps1
+++ b/src/UofICDB/Functions/Public/Remove-CDBConnection.ps1
@@ -17,18 +17,20 @@ function Remove-CDBConnection {
     )
 
     begin {
-
     }
 
     process {
-        $Script:Authorization = $Null
+        if($PSCmdlet.ShouldProcess("Clearing CDB connection")){
+            $Script:Authorization = $Null
+        }
 
-        if($ClearSaved){
-            Remove-Item -Path $Script:SavedCredsDir -Force
+        if($PSCmdlet.ShouldProcess("Removing cached credentials at $($Script:SavedCredsDir)")){
+            if($ClearSaved){
+                Remove-Item -Path $Script:SavedCredsDir -Force
+            }
         }
     }
 
     end {
-
     }
 }

--- a/src/UofICDB/Functions/Public/Remove-CDBConnection.ps1
+++ b/src/UofICDB/Functions/Public/Remove-CDBConnection.ps1
@@ -23,9 +23,9 @@ function Remove-CDBConnection {
         if($PSCmdlet.ShouldProcess("Clearing CDB connection")){
             $Script:Authorization = $Null
         }
-        
+
         if($ClearSaved){
-            if($PSCmdlet.ShouldProcess("Removing cached credentials at $($Script:SavedCredsDir)")){     
+            if($PSCmdlet.ShouldProcess("Removing cached credentials at $($Script:SavedCredsDir)")){
                 Remove-Item -Path $Script:SavedCredsDir -Force
             }
         }

--- a/src/UofICDB/Functions/Public/Remove-CDBConnection.ps1
+++ b/src/UofICDB/Functions/Public/Remove-CDBConnection.ps1
@@ -23,9 +23,9 @@ function Remove-CDBConnection {
         if($PSCmdlet.ShouldProcess("Clearing CDB connection")){
             $Script:Authorization = $Null
         }
-
-        if($PSCmdlet.ShouldProcess("Removing cached credentials at $($Script:SavedCredsDir)")){
-            if($ClearSaved){
+        
+        if($ClearSaved){
+            if($PSCmdlet.ShouldProcess("Removing cached credentials at $($Script:SavedCredsDir)")){     
                 Remove-Item -Path $Script:SavedCredsDir -Force
             }
         }

--- a/src/UofICDB/docs/Remove-CDBConnection.md
+++ b/src/UofICDB/docs/Remove-CDBConnection.md
@@ -5,49 +5,36 @@ online version:
 schema: 2.0.0
 ---
 
-# New-CDBConnection
+# Remove-CDBConnection
 
 ## SYNOPSIS
-This cmdlet will cache your CDB credentials for the session to be used with the other cmdlets in the UofICDB module.
+This cmdlet will clear cached CDB credentials.
 
 ## SYNTAX
 
 ```
-New-CDBConnection [-Credential] <PSCredential> [-Save] [-WhatIf] [-Confirm] [<CommonParameters>]
+Remove-CDBConnection [-ClearSaved] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
-This cmdlet will cache your CDB credentials for the session to be used with the other cmdlets in the UofICDB module.
+This cmdlet will clear cached CDB credentials.
 
 ## EXAMPLES
 
 ### EXAMPLE 1
 ```
-$Credential = Get-Credential
-New-CDBConnection -Credential $Credential
+Remove-CDBConnection
+```
+
+### EXAMPLE 2
+```
+Remove-CDBConnection -ClearSaved
 ```
 
 ## PARAMETERS
 
-### -Credential
-Your CDB API credentials.
-This will likely not be your NetID
-
-```yaml
-Type: PSCredential
-Parameter Sets: (All)
-Aliases:
-
-Required: True
-Position: 1
-Default value: None
-Accept pipeline input: False
-Accept wildcard characters: False
-```
-
-### -Save
-This will encrypt the encoded credentials and store them $ENV:LOCALAPPDATA\PSCDBAuth.txt on Windows or /home//.local/share/ on Linux for use between sessions.
-This will only be readable by the account that saves it on the machine it was saved.
+### -ClearSaved
+This will remove the saved credentials as well as the session credentials.
 
 ```yaml
 Type: SwitchParameter
@@ -62,7 +49,8 @@ Accept wildcard characters: False
 ```
 
 ### -WhatIf
-Shows what would happen if the cmdlet runs. The cmdlet is not run.
+Shows what would happen if the cmdlet runs.
+The cmdlet is not run.
 
 ```yaml
 Type: SwitchParameter


### PR DESCRIPTION
- SupportsShouldProcess was flagged but not properly implemented at this modules inception. Now -WhatIf will properly describe actions instead of performing then when provided for New/Remove-CDBConnection

- Regenerated PlatyPS docs